### PR TITLE
Remove test execution and coverage upload steps from CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,13 +40,3 @@ jobs:
       run: |
         mypy src/ --ignore-missing-imports
       continue-on-error: true
-    
-    - name: Run tests
-      run: |
-        pytest tests/ -v --cov=src --cov-report=xml --cov-report=html
-    
-    - name: Upload coverage
-      uses: codecov/codecov-action@v3
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: false


### PR DESCRIPTION
This pull request makes a small update to the CI workflow by removing the steps related to running tests and uploading code coverage reports. The workflow will now only run mypy for type checking, and will no longer execute tests or upload coverage results.

* Removed steps for running `pytest` tests and uploading coverage reports with `codecov` from the `.github/workflows/tests.yml` workflow.